### PR TITLE
SMC-130: [IP3] Missing the test cases for reserve

### DIFF
--- a/contracts/test/IP3Token.EthlessReserve.t.sol
+++ b/contracts/test/IP3Token.EthlessReserve.t.sol
@@ -105,7 +105,7 @@ contract IP3TokenTest is DSTest, SharedHelper {
 
         vm.prank(USER1);
         iP3Token.transfer(USER3, amountToTransfer);
-        
+
         assertEq(iP3Token.balanceOf(USER1), 0);
         assertEq(iP3Token.balanceOf(USER3), amountToTransfer);
     }
@@ -136,7 +136,7 @@ contract IP3TokenTest is DSTest, SharedHelper {
 
         vm.prank(USER1);
         iP3Token.transfer(USER3, amountToTransfer - 1);
-        
+
         assertEq(iP3Token.balanceOf(USER1), 1);
         assertEq(iP3Token.balanceOf(USER3), amountToTransfer - 1);
     }
@@ -168,7 +168,7 @@ contract IP3TokenTest is DSTest, SharedHelper {
         vm.prank(USER1);
         vm.expectRevert('IP3Token: Insufficient balance');
         iP3Token.transfer(USER3, amountToTransfer + 1);
-        
+
         assertEq(iP3Token.balanceOf(USER1), amountToTransfer);
         assertEq(iP3Token.balanceOf(USER3), 0);
     }

--- a/contracts/test/IP3Token.EthlessReserve.t.sol
+++ b/contracts/test/IP3Token.EthlessReserve.t.sol
@@ -78,4 +78,98 @@ contract IP3TokenTest is DSTest, SharedHelper {
         vm.expectRevert('Ethless: nonce already used');
         IP3Token(_ip3Token).reserve(USER1, USER3, USER4, amountToReserve, feeToPay, nonce, deadline, signature);
     }
+
+    function test_IP3Token_ethless_reserve_andTransferSameBlock() public {
+        uint256 amountToReserve = 500;
+        uint256 feeToPay = 100;
+        uint256 amountToTransfer = 400;
+
+        iP3Token.transfer(USER1, amountToReserve + feeToPay + amountToTransfer);
+        assertEq(iP3Token.balanceOf(USER1), amountToReserve + feeToPay + amountToTransfer);
+
+        uint256 nonce = 54645;
+        uint256 deadline = block.number + 10;
+
+        eip191_reserve_verified(
+            USER1,
+            USER1_PRIVATEKEY,
+            amountToReserve,
+            feeToPay,
+            nonce,
+            USER3,
+            USER4,
+            USER2,
+            deadline,
+            false
+        );
+
+        vm.prank(USER1);
+        iP3Token.transfer(USER3, amountToTransfer);
+        
+        assertEq(iP3Token.balanceOf(USER1), 0);
+        assertEq(iP3Token.balanceOf(USER3), amountToTransfer);
+    }
+
+    function test_IP3Token_ethless_reserve_andTransferLessSameBlock() public {
+        uint256 amountToReserve = 500;
+        uint256 feeToPay = 100;
+        uint256 amountToTransfer = 400;
+
+        iP3Token.transfer(USER1, amountToReserve + feeToPay + amountToTransfer);
+        assertEq(iP3Token.balanceOf(USER1), amountToReserve + feeToPay + amountToTransfer);
+
+        uint256 nonce = 54645;
+        uint256 deadline = block.number + 10;
+
+        eip191_reserve_verified(
+            USER1,
+            USER1_PRIVATEKEY,
+            amountToReserve,
+            feeToPay,
+            nonce,
+            USER3,
+            USER4,
+            USER2,
+            deadline,
+            false
+        );
+
+        vm.prank(USER1);
+        iP3Token.transfer(USER3, amountToTransfer - 1);
+        
+        assertEq(iP3Token.balanceOf(USER1), 1);
+        assertEq(iP3Token.balanceOf(USER3), amountToTransfer - 1);
+    }
+
+    function test_IP3Token_ethless_reserve_andTransferMoreSameBlock() public {
+        uint256 amountToReserve = 500;
+        uint256 feeToPay = 100;
+        uint256 amountToTransfer = 400;
+
+        iP3Token.transfer(USER1, amountToReserve + feeToPay + amountToTransfer);
+        assertEq(iP3Token.balanceOf(USER1), amountToReserve + feeToPay + amountToTransfer);
+
+        uint256 nonce = 54645;
+        uint256 deadline = block.number + 10;
+
+        eip191_reserve_verified(
+            USER1,
+            USER1_PRIVATEKEY,
+            amountToReserve,
+            feeToPay,
+            nonce,
+            USER3,
+            USER4,
+            USER2,
+            deadline,
+            false
+        );
+
+        vm.prank(USER1);
+        vm.expectRevert('IP3Token: Insufficient balance');
+        iP3Token.transfer(USER3, amountToTransfer + 1);
+        
+        assertEq(iP3Token.balanceOf(USER1), amountToTransfer);
+        assertEq(iP3Token.balanceOf(USER3), 0);
+    }
 }

--- a/test/IP3Token.EthlessReserve.test.js
+++ b/test/IP3Token.EthlessReserve.test.js
@@ -363,11 +363,14 @@ describe('IP3Token - Ethless Reserve functions', function () {
                 ethers.BigNumber.from(originalBalance).sub(amountToReserve).sub(feeToPay)
             );
 
-            await IP3Token.connect(owner)['transfer(address,uint256)'](user2.address, amountToReserve.sub(feeToPay).sub(1));
+            await IP3Token.connect(owner)['transfer(address,uint256)'](
+                user2.address,
+                amountToReserve.sub(feeToPay).sub(1)
+            );
             expect(await IP3Token.balanceOf(owner.address)).to.equal(1);
             expect(await IP3Token.balanceOf(user2.address)).to.equal(amountToReserve.sub(feeToPay).sub(1));
         });
-        
+
         it('Test Ethless Reserve with receiver as address zero', async () => {
             const originalBalance = await IP3Token.balanceOf(owner.address);
 
@@ -390,22 +393,13 @@ describe('IP3Token - Ethless Reserve functions', function () {
             );
             const input = await IP3Token.connect(user3).populateTransaction[
                 'reserve(address,address,address,uint256,uint256,uint256,uint256,bytes)'
-            ](
-                owner.address,
-                zeroAddress,
-                owner.address,
-                amountToReserve,
-                feeToPay,
-                nonce,
-                expirationBlock,
-                signature
-            );
+            ](owner.address, zeroAddress, owner.address, amountToReserve, feeToPay, nonce, expirationBlock, signature);
             await TestHelper.checkResult(input, IP3Token.address, user3, ethers, provider, 0);
             expect(await IP3Token.balanceOf(owner.address)).to.equal(
                 ethers.BigNumber.from(originalBalance).sub(amountToReserve).sub(feeToPay)
             );
         });
-        
+
         it('Test Ethless Reserve with executor as address zero', async () => {
             const originalBalance = await IP3Token.balanceOf(owner.address);
 
@@ -428,16 +422,7 @@ describe('IP3Token - Ethless Reserve functions', function () {
             );
             const input = await IP3Token.connect(user3).populateTransaction[
                 'reserve(address,address,address,uint256,uint256,uint256,uint256,bytes)'
-            ](
-                owner.address,
-                user1.address,
-                zeroAddress,
-                amountToReserve,
-                feeToPay,
-                nonce,
-                expirationBlock,
-                signature
-            );
+            ](owner.address, user1.address, zeroAddress, amountToReserve, feeToPay, nonce, expirationBlock, signature);
             await TestHelper.checkResult(input, IP3Token.address, user3, ethers, provider, 0);
             expect(await IP3Token.balanceOf(owner.address)).to.equal(
                 ethers.BigNumber.from(originalBalance).sub(amountToReserve).sub(feeToPay)
@@ -488,7 +473,10 @@ describe('IP3Token - Ethless Reserve functions', function () {
                 ethers.BigNumber.from(originalBalance).sub(amountToReserve).sub(feeToPay)
             );
 
-            const inputTransfer = await IP3Token.connect(owner).populateTransaction['transfer(address,uint256)'](user2.address, amountToReserve.add(1));
+            const inputTransfer = await IP3Token.connect(owner).populateTransaction['transfer(address,uint256)'](
+                user2.address,
+                amountToReserve.add(1)
+            );
             await TestHelper.checkResult(
                 inputTransfer,
                 IP3Token.address,
@@ -500,8 +488,8 @@ describe('IP3Token - Ethless Reserve functions', function () {
             expect(await IP3Token.balanceOf(owner.address)).to.equal(amountToReserve.sub(feeToPay));
             expect(await IP3Token.balanceOf(user2.address)).to.equal(0);
         });
-        
-        it('Test Ethless Reserve with receiver as address zero', async () => {
+
+        it('Test Ethless Reserve with receiver as address zero and reclaim', async () => {
             const originalBalance = await IP3Token.balanceOf(owner.address);
 
             const nonce = Date.now();
@@ -523,16 +511,7 @@ describe('IP3Token - Ethless Reserve functions', function () {
             );
             const input = await IP3Token.connect(user3).populateTransaction[
                 'reserve(address,address,address,uint256,uint256,uint256,uint256,bytes)'
-            ](
-                owner.address,
-                zeroAddress,
-                owner.address,
-                amountToReserve,
-                feeToPay,
-                nonce,
-                expirationBlock,
-                signature
-            );
+            ](owner.address, zeroAddress, owner.address, amountToReserve, feeToPay, nonce, expirationBlock, signature);
             await TestHelper.checkResult(input, IP3Token.address, user3, ethers, provider, 0);
             expect(await IP3Token.balanceOf(owner.address)).to.equal(
                 ethers.BigNumber.from(originalBalance).sub(amountToReserve).sub(feeToPay)
@@ -546,8 +525,43 @@ describe('IP3Token - Ethless Reserve functions', function () {
             expect(await IP3Token.balanceOf(owner.address)).to.equal(ethers.BigNumber.from(originalBalance));
             expect(await IP3Token.balanceOf(user1.address)).to.equal(ethers.BigNumber.from(0));
         });
-        
-        it('Test Ethless Reserve with executor as address zero', async () => {
+
+        it('Test Ethless Reserve with receiver as address zero and try to execute', async () => {
+            const originalBalance = await IP3Token.balanceOf(owner.address);
+
+            const nonce = Date.now();
+            const blockNumber = await provider.getBlockNumber();
+            const expirationBlock = blockNumber + 2000;
+
+            const signature = SignHelper.signReserve(
+                4,
+                network.config.chainId,
+                IP3Token.address,
+                owner.address,
+                owner.privateKey,
+                zeroAddress,
+                owner.address,
+                amountToReserve,
+                feeToPay,
+                nonce,
+                expirationBlock
+            );
+            const input = await IP3Token.connect(user3).populateTransaction[
+                'reserve(address,address,address,uint256,uint256,uint256,uint256,bytes)'
+            ](owner.address, zeroAddress, owner.address, amountToReserve, feeToPay, nonce, expirationBlock, signature);
+            await TestHelper.checkResult(input, IP3Token.address, user3, ethers, provider, 0);
+            expect(await IP3Token.balanceOf(owner.address)).to.equal(
+                ethers.BigNumber.from(originalBalance).sub(amountToReserve).sub(feeToPay)
+            );
+
+            const inputReclaim = await IP3Token.connect(owner).populateTransaction['execute(address,uint256)'](
+                owner.address,
+                nonce
+            );
+            await TestHelper.checkResult(inputReclaim, IP3Token.address, owner, ethers, provider, 'ERC20: transfer to the zero address');
+        });
+
+        it('Test Ethless Reserve with executor as address zero and reclaim when reservation expired', async () => {
             const originalBalance = await IP3Token.balanceOf(owner.address);
 
             const nonce = Date.now();
@@ -569,23 +583,14 @@ describe('IP3Token - Ethless Reserve functions', function () {
             );
             const input = await IP3Token.connect(user3).populateTransaction[
                 'reserve(address,address,address,uint256,uint256,uint256,uint256,bytes)'
-            ](
-                owner.address,
-                user1.address,
-                zeroAddress,
-                amountToReserve,
-                feeToPay,
-                nonce,
-                expirationBlock,
-                signature
-            );
+            ](owner.address, user1.address, zeroAddress, amountToReserve, feeToPay, nonce, expirationBlock, signature);
             await TestHelper.checkResult(input, IP3Token.address, user3, ethers, provider, 0);
             expect(await IP3Token.balanceOf(owner.address)).to.equal(
                 ethers.BigNumber.from(originalBalance).sub(amountToReserve).sub(feeToPay)
             );
 
             await TestHelper.waitForNumberOfBlock(provider, expirationBlock + 1);
-            
+
             const inputReclaim = await IP3Token.connect(owner).populateTransaction['reclaim(address,uint256)'](
                 owner.address,
                 nonce

--- a/test/IP3Token.EthlessReserve.test.js
+++ b/test/IP3Token.EthlessReserve.test.js
@@ -558,7 +558,14 @@ describe('IP3Token - Ethless Reserve functions', function () {
                 owner.address,
                 nonce
             );
-            await TestHelper.checkResult(inputReclaim, IP3Token.address, owner, ethers, provider, 'ERC20: transfer to the zero address');
+            await TestHelper.checkResult(
+                inputReclaim,
+                IP3Token.address,
+                owner,
+                ethers,
+                provider,
+                'ERC20: transfer to the zero address'
+            );
         });
 
         it('Test Ethless Reserve with executor as address zero and reclaim when reservation expired', async () => {

--- a/test/IP3Token.EthlessReserve.test.js
+++ b/test/IP3Token.EthlessReserve.test.js
@@ -242,11 +242,358 @@ describe('IP3Token - Ethless Reserve functions', function () {
             expect(await IP3Token.balanceOf(owner.address)).to.equal(ethers.BigNumber.from(originalBalance));
             expect(await IP3Token.balanceOf(user1.address)).to.equal(ethers.BigNumber.from(0));
         });
+        it('Test Ethless Reserve current total balance', async () => {
+            const originalBalance = await IP3Token.balanceOf(owner.address);
+
+            const amountToReserve = originalBalance.sub(feeToPay);
+
+            const nonce = Date.now();
+            const blockNumber = await provider.getBlockNumber();
+            const expirationBlock = blockNumber + 2000;
+
+            const signature = SignHelper.signReserve(
+                4,
+                network.config.chainId,
+                IP3Token.address,
+                owner.address,
+                owner.privateKey,
+                user1.address,
+                owner.address,
+                amountToReserve,
+                feeToPay,
+                nonce,
+                expirationBlock
+            );
+            const input = await IP3Token.connect(user3).populateTransaction[
+                'reserve(address,address,address,uint256,uint256,uint256,uint256,bytes)'
+            ](
+                owner.address,
+                user1.address,
+                owner.address,
+                amountToReserve,
+                feeToPay,
+                nonce,
+                expirationBlock,
+                signature
+            );
+            await TestHelper.checkResult(input, IP3Token.address, user3, ethers, provider, 0);
+            expect(await IP3Token.balanceOf(owner.address)).to.equal(
+                ethers.BigNumber.from(originalBalance).sub(amountToReserve).sub(feeToPay)
+            );
+        });
+        it('Test Ethless Reserve half of balance and transfer half away', async () => {
+            const originalBalance = await IP3Token.balanceOf(owner.address);
+
+            const amountToReserve = originalBalance.div(2);
+
+            const nonce = Date.now();
+            const blockNumber = await provider.getBlockNumber();
+            const expirationBlock = blockNumber + 2000;
+
+            const signature = SignHelper.signReserve(
+                4,
+                network.config.chainId,
+                IP3Token.address,
+                owner.address,
+                owner.privateKey,
+                user1.address,
+                owner.address,
+                amountToReserve,
+                feeToPay,
+                nonce,
+                expirationBlock
+            );
+            const input = await IP3Token.connect(user3).populateTransaction[
+                'reserve(address,address,address,uint256,uint256,uint256,uint256,bytes)'
+            ](
+                owner.address,
+                user1.address,
+                owner.address,
+                amountToReserve,
+                feeToPay,
+                nonce,
+                expirationBlock,
+                signature
+            );
+            await TestHelper.checkResult(input, IP3Token.address, user3, ethers, provider, 0);
+            expect(await IP3Token.balanceOf(owner.address)).to.equal(
+                ethers.BigNumber.from(originalBalance).sub(amountToReserve).sub(feeToPay)
+            );
+
+            await IP3Token.connect(owner)['transfer(address,uint256)'](user2.address, amountToReserve.sub(feeToPay));
+            expect(await IP3Token.balanceOf(owner.address)).to.equal(0);
+            expect(await IP3Token.balanceOf(user2.address)).to.equal(amountToReserve.sub(feeToPay));
+        });
+        it('Test Ethless Reserve half of balance and transfer half away -1', async () => {
+            const originalBalance = await IP3Token.balanceOf(owner.address);
+
+            const amountToReserve = originalBalance.div(2);
+
+            const nonce = Date.now();
+            const blockNumber = await provider.getBlockNumber();
+            const expirationBlock = blockNumber + 2000;
+
+            const signature = SignHelper.signReserve(
+                4,
+                network.config.chainId,
+                IP3Token.address,
+                owner.address,
+                owner.privateKey,
+                user1.address,
+                owner.address,
+                amountToReserve,
+                feeToPay,
+                nonce,
+                expirationBlock
+            );
+            const input = await IP3Token.connect(user3).populateTransaction[
+                'reserve(address,address,address,uint256,uint256,uint256,uint256,bytes)'
+            ](
+                owner.address,
+                user1.address,
+                owner.address,
+                amountToReserve,
+                feeToPay,
+                nonce,
+                expirationBlock,
+                signature
+            );
+            await TestHelper.checkResult(input, IP3Token.address, user3, ethers, provider, 0);
+            expect(await IP3Token.balanceOf(owner.address)).to.equal(
+                ethers.BigNumber.from(originalBalance).sub(amountToReserve).sub(feeToPay)
+            );
+
+            await IP3Token.connect(owner)['transfer(address,uint256)'](user2.address, amountToReserve.sub(feeToPay).sub(1));
+            expect(await IP3Token.balanceOf(owner.address)).to.equal(1);
+            expect(await IP3Token.balanceOf(user2.address)).to.equal(amountToReserve.sub(feeToPay).sub(1));
+        });
+        
+        it('Test Ethless Reserve with receiver as address zero', async () => {
+            const originalBalance = await IP3Token.balanceOf(owner.address);
+
+            const nonce = Date.now();
+            const blockNumber = await provider.getBlockNumber();
+            const expirationBlock = blockNumber + 2000;
+
+            const signature = SignHelper.signReserve(
+                4,
+                network.config.chainId,
+                IP3Token.address,
+                owner.address,
+                owner.privateKey,
+                zeroAddress,
+                owner.address,
+                amountToReserve,
+                feeToPay,
+                nonce,
+                expirationBlock
+            );
+            const input = await IP3Token.connect(user3).populateTransaction[
+                'reserve(address,address,address,uint256,uint256,uint256,uint256,bytes)'
+            ](
+                owner.address,
+                zeroAddress,
+                owner.address,
+                amountToReserve,
+                feeToPay,
+                nonce,
+                expirationBlock,
+                signature
+            );
+            await TestHelper.checkResult(input, IP3Token.address, user3, ethers, provider, 0);
+            expect(await IP3Token.balanceOf(owner.address)).to.equal(
+                ethers.BigNumber.from(originalBalance).sub(amountToReserve).sub(feeToPay)
+            );
+        });
+        
+        it('Test Ethless Reserve with executor as address zero', async () => {
+            const originalBalance = await IP3Token.balanceOf(owner.address);
+
+            const nonce = Date.now();
+            const blockNumber = await provider.getBlockNumber();
+            const expirationBlock = blockNumber + 2000;
+
+            const signature = SignHelper.signReserve(
+                4,
+                network.config.chainId,
+                IP3Token.address,
+                owner.address,
+                owner.privateKey,
+                user1.address,
+                zeroAddress,
+                amountToReserve,
+                feeToPay,
+                nonce,
+                expirationBlock
+            );
+            const input = await IP3Token.connect(user3).populateTransaction[
+                'reserve(address,address,address,uint256,uint256,uint256,uint256,bytes)'
+            ](
+                owner.address,
+                user1.address,
+                zeroAddress,
+                amountToReserve,
+                feeToPay,
+                nonce,
+                expirationBlock,
+                signature
+            );
+            await TestHelper.checkResult(input, IP3Token.address, user3, ethers, provider, 0);
+            expect(await IP3Token.balanceOf(owner.address)).to.equal(
+                ethers.BigNumber.from(originalBalance).sub(amountToReserve).sub(feeToPay)
+            );
+        });
     });
 
     describe('IP3Token - Test expecting failure Ethless Reserve', async function () {
         const amountToReserve = 1000;
         const feeToPay = 10;
+
+        it('Test Ethless Reserve half of balance and transfer half +1 away', async () => {
+            const originalBalance = await IP3Token.balanceOf(owner.address);
+
+            const amountToReserve = originalBalance.div(2);
+
+            const nonce = Date.now();
+            const blockNumber = await provider.getBlockNumber();
+            const expirationBlock = blockNumber + 2000;
+
+            const signature = SignHelper.signReserve(
+                4,
+                network.config.chainId,
+                IP3Token.address,
+                owner.address,
+                owner.privateKey,
+                user1.address,
+                owner.address,
+                amountToReserve,
+                feeToPay,
+                nonce,
+                expirationBlock
+            );
+            const input = await IP3Token.connect(user3).populateTransaction[
+                'reserve(address,address,address,uint256,uint256,uint256,uint256,bytes)'
+            ](
+                owner.address,
+                user1.address,
+                owner.address,
+                amountToReserve,
+                feeToPay,
+                nonce,
+                expirationBlock,
+                signature
+            );
+            await TestHelper.checkResult(input, IP3Token.address, user3, ethers, provider, 0);
+            expect(await IP3Token.balanceOf(owner.address)).to.equal(
+                ethers.BigNumber.from(originalBalance).sub(amountToReserve).sub(feeToPay)
+            );
+
+            const inputTransfer = await IP3Token.connect(owner).populateTransaction['transfer(address,uint256)'](user2.address, amountToReserve.add(1));
+            await TestHelper.checkResult(
+                inputTransfer,
+                IP3Token.address,
+                owner,
+                ethers,
+                provider,
+                'IP3Token: Insufficient balance'
+            );
+            expect(await IP3Token.balanceOf(owner.address)).to.equal(amountToReserve.sub(feeToPay));
+            expect(await IP3Token.balanceOf(user2.address)).to.equal(0);
+        });
+        
+        it('Test Ethless Reserve with receiver as address zero', async () => {
+            const originalBalance = await IP3Token.balanceOf(owner.address);
+
+            const nonce = Date.now();
+            const blockNumber = await provider.getBlockNumber();
+            const expirationBlock = blockNumber + 2000;
+
+            const signature = SignHelper.signReserve(
+                4,
+                network.config.chainId,
+                IP3Token.address,
+                owner.address,
+                owner.privateKey,
+                zeroAddress,
+                owner.address,
+                amountToReserve,
+                feeToPay,
+                nonce,
+                expirationBlock
+            );
+            const input = await IP3Token.connect(user3).populateTransaction[
+                'reserve(address,address,address,uint256,uint256,uint256,uint256,bytes)'
+            ](
+                owner.address,
+                zeroAddress,
+                owner.address,
+                amountToReserve,
+                feeToPay,
+                nonce,
+                expirationBlock,
+                signature
+            );
+            await TestHelper.checkResult(input, IP3Token.address, user3, ethers, provider, 0);
+            expect(await IP3Token.balanceOf(owner.address)).to.equal(
+                ethers.BigNumber.from(originalBalance).sub(amountToReserve).sub(feeToPay)
+            );
+
+            const inputReclaim = await IP3Token.connect(owner).populateTransaction['reclaim(address,uint256)'](
+                owner.address,
+                nonce
+            );
+            await TestHelper.checkResult(inputReclaim, IP3Token.address, owner, ethers, provider, 0);
+            expect(await IP3Token.balanceOf(owner.address)).to.equal(ethers.BigNumber.from(originalBalance));
+            expect(await IP3Token.balanceOf(user1.address)).to.equal(ethers.BigNumber.from(0));
+        });
+        
+        it('Test Ethless Reserve with executor as address zero', async () => {
+            const originalBalance = await IP3Token.balanceOf(owner.address);
+
+            const nonce = Date.now();
+            const blockNumber = await provider.getBlockNumber();
+            const expirationBlock = blockNumber + 2000;
+
+            const signature = SignHelper.signReserve(
+                4,
+                network.config.chainId,
+                IP3Token.address,
+                owner.address,
+                owner.privateKey,
+                user1.address,
+                zeroAddress,
+                amountToReserve,
+                feeToPay,
+                nonce,
+                expirationBlock
+            );
+            const input = await IP3Token.connect(user3).populateTransaction[
+                'reserve(address,address,address,uint256,uint256,uint256,uint256,bytes)'
+            ](
+                owner.address,
+                user1.address,
+                zeroAddress,
+                amountToReserve,
+                feeToPay,
+                nonce,
+                expirationBlock,
+                signature
+            );
+            await TestHelper.checkResult(input, IP3Token.address, user3, ethers, provider, 0);
+            expect(await IP3Token.balanceOf(owner.address)).to.equal(
+                ethers.BigNumber.from(originalBalance).sub(amountToReserve).sub(feeToPay)
+            );
+
+            await TestHelper.waitForNumberOfBlock(provider, expirationBlock + 1);
+            
+            const inputReclaim = await IP3Token.connect(owner).populateTransaction['reclaim(address,uint256)'](
+                owner.address,
+                nonce
+            );
+            await TestHelper.checkResult(inputReclaim, IP3Token.address, owner, ethers, provider, 0);
+            expect(await IP3Token.balanceOf(owner.address)).to.equal(ethers.BigNumber.from(originalBalance));
+            expect(await IP3Token.balanceOf(user1.address)).to.equal(ethers.BigNumber.from(0));
+        });
 
         it('Test Ethless Reserve while reusing the same nonce (and signature) on the second reserve', async () => {
             const originalBalance = await IP3Token.balanceOf(owner.address);
@@ -435,7 +782,7 @@ describe('IP3Token - Ethless Reserve functions', function () {
         it('Test Ethless Reserve while expirationBlock is lower than the current block.number', async () => {
             const nonce = Date.now();
             const blockNumber = await provider.getBlockNumber();
-            const expirationBlock = blockNumber - 100;
+            const expirationBlock = blockNumber - 40;
 
             const signature = SignHelper.signReserve(
                 4,

--- a/test/shared.js
+++ b/test/shared.js
@@ -111,6 +111,21 @@ const checkResult = async (input, to, from, ethers, provider, errMsg) => {
     }
 };
 
+const waitForNumberOfBlock = async (provider, numberOfBlock) => {
+    const currentBlock = await provider.getBlockNumber();
+    let temp = await provider.getBlockNumber();
+    while (temp < currentBlock + numberOfBlock) {
+        if (network.name === 'hardhat') {
+            // Mine 1 block
+            await provider.send('evm_mine');
+        } else {
+            // wait 14 seconds
+            await new Promise((resolve) => setTimeout(resolve, 10000));
+        }
+        temp = await provider.getBlockNumber();
+    }
+};
+
 module.exports = {
     // CONSTANTS
     NAME,
@@ -124,5 +139,6 @@ module.exports = {
     setupProviderAndWallet,
     setupContractTesting,
     txn,
-    checkResult
+    checkResult,
+    waitForNumberOfBlock
 };

--- a/test/shared.js
+++ b/test/shared.js
@@ -119,8 +119,8 @@ const waitForNumberOfBlock = async (provider, numberOfBlock) => {
             // Mine 1 block
             await provider.send('evm_mine');
         } else {
-            // wait 14 seconds
-            await new Promise((resolve) => setTimeout(resolve, 10000));
+            // wait 15 seconds
+            await new Promise((resolve) => setTimeout(resolve, 15000));
         }
         temp = await provider.getBlockNumber();
     }


### PR DESCRIPTION
## Notable changes
- Add more tests for reserve function
- Test using address(0) as executor or receiver of the reservation does not fail
    - If receiver is address(0) and we execute the reservation, the execute tx will fail for trying to send token to address(0) but executor can still reclaim the reservation
    - if executor is address(0) the owner will need to wait for reservation to expire to reclaim